### PR TITLE
Add RabbitMQ Operator 2.16.0

### DIFF
--- a/repo/packages/rabbitmq-operator.packages.kadras.io/2.16.0.yml
+++ b/repo/packages/rabbitmq-operator.packages.kadras.io/2.16.0.yml
@@ -1,0 +1,44 @@
+apiVersion: data.packaging.carvel.dev/v1alpha1
+kind: Package
+metadata:
+  creationTimestamp: null
+  name: rabbitmq-operator.packages.kadras.io.2.16.0
+spec:
+  licenses:
+  - Apache 2.0
+  refName: rabbitmq-operator.packages.kadras.io
+  releaseNotes: https://github.com/kadras-io/package-for-rabbitmq-operator/releases
+  releasedAt: "2025-08-14T17:59:56Z"
+  template:
+    spec:
+      deploy:
+      - kapp: {}
+      fetch:
+      - imgpkgBundle:
+          image: ghcr.io/kadras-io/package-for-rabbitmq-operator@sha256:8b6e5549a49b6ec947878770d4fa317c1f90a12b655db7c838cf84df9e6f0b11
+      template:
+      - ytt:
+          paths:
+          - config
+      - kbld:
+          paths:
+          - '-'
+          - .imgpkg/images.yml
+  valuesSchema:
+    openAPIv3:
+      additionalProperties: false
+      properties:
+        logging:
+          additionalProperties: false
+          description: Logging configuration.
+          properties:
+            level:
+              default: info
+              description: The Operator log level. Valid options are `info` and `debug`.
+              enum:
+              - info
+              - debug
+              type: string
+          type: object
+      type: object
+  version: 2.16.0


### PR DESCRIPTION
Update RabbitMQ Operator metadata and add version 2.16.0